### PR TITLE
Remove display: block

### DIFF
--- a/lancie-error.html
+++ b/lancie-error.html
@@ -13,10 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="lancie-error">
   <template>
     <style>
-      :host {
-        display: block;
-      }
-
       .container {
         width: inherit;
         padding: 10px 20px;


### PR DESCRIPTION
Now the buttons do not save space for the error and come directly after the previous element.